### PR TITLE
Add epsilon rules for problems with epsilon terms on the input

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,1 +1,2 @@
 - Frédéric Blanqui
+- Guillaume Burel

--- a/Implem_Epsilon.lp
+++ b/Implem_Epsilon.lp
@@ -1,4 +1,4 @@
-require open Stdlib.Prop Stdlib.Set Stdlib.Eq Stdlib.FOL Stdlib.Epsilon Logic.Zenon.Main;
+require open Stdlib.Epsilon Logic.Zenon.Main;
 
 symbol Reps a (p : τ a → Prop) : (π (p (ε p)) → π ⊥) → π (∃ p) → π ⊥ ≔
 begin

--- a/Implem_Epsilon.lp
+++ b/Implem_Epsilon.lp
@@ -1,0 +1,18 @@
+require open Stdlib.Prop Stdlib.Set Stdlib.Eq Stdlib.FOL Stdlib.Epsilon Logic.Zenon.Main;
+
+symbol Reps a (p : τ a → Prop) : (π (p (ε p)) → π ⊥) → π (∃ p) → π ⊥ ≔
+begin
+  assume a p peps pex;
+  refine peps (εᵢ p pex);
+end;
+
+symbol Rnoteps a (p : τ a → Prop) : (π (¬ p (ε (λ x, ¬ p x))) → π ⊥) → π (¬ ∀ (λ x, p x)) → π ⊥ ≔
+begin
+  assume a p peps pnall;
+  refine Rnotall a (λ x, p x) _ pnall;
+  assume t pnpt;
+  have h : π(`∃ x, ¬ p x) {
+    apply ∃ᵢ t pnpt;
+};
+  refine (εᵢ (λ x, ¬ p x) h (nnpp _ peps));
+end;

--- a/Main_Epsilon.lp
+++ b/Main_Epsilon.lp
@@ -1,5 +1,4 @@
 require open Stdlib.Epsilon;
 
-
 symbol Reps a (p : τ a → Prop) : (π (p (ε p)) → π ⊥) → π (∃ p) → π ⊥;
 symbol Rnoteps a (p : τ a → Prop) : (π (¬ p (ε (λ x, ¬ p x))) → π ⊥) → π (¬ ∀ (λ x, p x)) → π ⊥;

--- a/Main_Epsilon.lp
+++ b/Main_Epsilon.lp
@@ -1,0 +1,5 @@
+require open Stdlib.Prop Stdlib.Set Stdlib.Eq Stdlib.FOL Stdlib.Epsilon;
+
+
+symbol Reps a (p : τ a → Prop) : (π (p (ε p)) → π ⊥) → π (∃ p) → π ⊥;
+symbol Rnoteps a (p : τ a → Prop) : (π (¬ p (ε (λ x, ¬ p x))) → π ⊥) → π (¬ ∀ (λ x, p x)) → π ⊥;

--- a/Main_Epsilon.lp
+++ b/Main_Epsilon.lp
@@ -1,4 +1,4 @@
-require open Stdlib.Prop Stdlib.Set Stdlib.Eq Stdlib.FOL Stdlib.Epsilon;
+require open Stdlib.Epsilon;
 
 
 symbol Reps a (p : τ a → Prop) : (π (p (ε p)) → π ⊥) → π (∃ p) → π ⊥;


### PR DESCRIPTION
New inference rules using Hilbert's epsilon axiom.

Useful when the epsilon term cannot be eliminated because it is on the input.
